### PR TITLE
Re-enable flow for .js files

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,7 @@
 [lints]
 
 [options]
+module.file_ext=.js
 module.file_ext=.vue
 
 [strict]

--- a/.flowconfig
+++ b/.flowconfig
@@ -9,5 +9,6 @@
 [options]
 module.file_ext=.js
 module.file_ext=.vue
+module.name_mapper='^@' -> '<PROJECT_ROOT>/src/renderer'
 
 [strict]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:integration:start-server": "karma start test/integration/karma.conf.js",
     "unit:start-server": "karma start test/unit/karma.conf.js",
     "unit:run": "karma run test/unit/karma.conf.js",
-    "ci": "yarn lint && yarn flow && yarn unit"
+    "ci": "yarn lint && yarn unit"
   },
   "build": {
     "productName": "Mysterion",

--- a/src/renderer/store/modules/connection.js
+++ b/src/renderer/store/modules/connection.js
@@ -19,7 +19,7 @@ type ConnectionStore = {
   ip: ?string,
   status: ConnectionStatus,
   statistics: Object,
-  actionLoopers: Map<string, FunctionLooper>
+  actionLoopers: { [string]: FunctionLooper }
 }
 
 class ActionLooper {
@@ -59,7 +59,7 @@ const getters = {
   connection (state: ConnectionStore): ConnectionStore {
     return state
   },
-  ip (state: ConnectionStore): string {
+  ip (state: ConnectionStore): ?string {
     return state.ip
   }
 }
@@ -181,7 +181,7 @@ function actionsFactory (
         }
 
         commit(type.SHOW_ERROR_MESSAGE, messages.connectFailed)
-        let error = new Error('Connection to node failed.')
+        const error: Object = new Error('Connection to node failed.')
         error.original = err
         eventTracker.connectEnded(error.toString())
         throw error

--- a/src/renderer/store/modules/main.js
+++ b/src/renderer/store/modules/main.js
@@ -13,14 +13,16 @@ const state = {
   showError: false
 }
 
+// TODO: add type for state
+
 const getters = {
-  loading: state => (state.init === type.INIT_PENDING),
-  visual: state => state.visual,
-  navOpen: state => state.navOpen,
-  navVisible: state => state.navVisible && !(state.init === type.INIT_PENDING),
-  clientBuildInfo: state => state.clientBuildInfo,
-  errorMessage: state => state.errorMessage,
-  showError: state => state.showError
+  loading: (state: Object) => (state.init === type.INIT_PENDING),
+  visual: (state: Object) => state.visual,
+  navOpen: (state: Object) => state.navOpen,
+  navVisible: (state: Object) => state.navVisible && !(state.init === type.INIT_PENDING),
+  clientBuildInfo: (state: Object) => state.clientBuildInfo,
+  errorMessage: (state: Object) => state.errorMessage,
+  showError: (state: Object) => state.showError
 }
 
 const mutations = {

--- a/test/helpers/dependencies.js
+++ b/test/helpers/dependencies.js
@@ -10,8 +10,9 @@ declare var describe: Function
 declare var it: Function
 declare var before: Function
 declare var beforeEach: Function
+declare var after: Function
 
 // chai
 declare var expect: Function
 
-export { describe, it, expect, before, beforeEach }
+export { describe, it, expect, before, beforeEach, after }

--- a/test/unit/app/data-fetchers/proposal-fetcher.spec.js
+++ b/test/unit/app/data-fetchers/proposal-fetcher.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import {describe, it, expect} from '../../../helpers/dependencies'
+import {describe, it, expect, before, beforeEach, after} from '../../../helpers/dependencies'
 import lolex from 'lolex'
 import ProposalFetcher from '../../../../src/app/data-fetchers/proposal-fetcher'
 import ProposalDTO from '../../../../src/libraries/mysterium-tequilapi/dto/proposal'
@@ -30,8 +30,8 @@ describe('DataFetchers', () => {
     }
 
     const tequilapi = mockTequilapiClient([
-      {id: '0x1'},
-      {id: '0x2'}
+      new ProposalDTO({id: '0x1'}),
+      new ProposalDTO({id: '0x2'})
     ])
 
     let fetcher
@@ -66,8 +66,8 @@ describe('DataFetchers', () => {
         await tickWithDelay(1000)
 
         expect(proposals.length).to.equal(2)
-        expect(proposals[0]).to.deep.equal({id: '0x1'})
-        expect(proposals[1]).to.deep.equal({id: '0x2'})
+        expect(proposals[0]).to.deep.equal(new ProposalDTO({id: '0x1'}))
+        expect(proposals[1]).to.deep.equal(new ProposalDTO({id: '0x2'}))
       })
 
       it('stops', async () => {
@@ -92,8 +92,8 @@ describe('DataFetchers', () => {
         const proposals = await fetcher.fetch()
 
         expect(proposals.length).to.equal(2)
-        expect(proposals[0]).to.deep.equal({id: '0x1'})
-        expect(proposals[1]).to.deep.equal({id: '0x2'})
+        expect(proposals[0]).to.deep.equal(new ProposalDTO({id: '0x1'}))
+        expect(proposals[1]).to.deep.equal(new ProposalDTO({id: '0x2'}))
       })
     })
   })


### PR DESCRIPTION
Flow checks for *.js* files were accidentally disable - it was working only for *.vue*.
This PR:
- Re-enables Flow checks for *.js* files
- Makes Flow aware of '@' alias in import statements
- Fixes some of Flow warnings
- Temporary removes Flow checking from CI - until we clean-up all errors. There are many errors, so fixing all of them with one PR is an overkill and will cause too many conflicts.