### PR TITLE
Do not release same version twice when tagging semantic version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ deploy:
     target-branch: mysterion_$TRAVIS_OS_NAME
     repo: MysteriumNetwork/build-artifacts
     on:
+      tags: false
       branch: master
   - provider: releases
     file_glob: true


### PR DESCRIPTION
From https://docs.travis-ci.com/user/customizing-the-build:

> Note that `before_deploy` and `after_deploy` are run before and after every deploy provider, so will run multiple times if there are multiple providers.
