### PR TITLE
hotfix. new identity is created each time Mysterion is run

### DIFF
--- a/src/libraries/mysterium-tequilapi/dto/identities-response.js
+++ b/src/libraries/mysterium-tequilapi/dto/identities-response.js
@@ -18,14 +18,14 @@
 // @flow
 import IdentityDTO from './identity'
 
-type ResponseMap = Array<Object>
+type IdentityListResponse = { identities: Array<Object> }
 
 class IdentitiesResponseDTO {
   identities: Array<IdentityDTO>
 
-  constructor (responseData: ResponseMap) {
-    if (typeof responseData !== 'undefined' && Array.isArray(responseData)) {
-      this.identities = responseData.map((identity) => new IdentityDTO(identity))
+  constructor (responseData: IdentityListResponse) {
+    if (responseData && Array.isArray(responseData.identities)) {
+      this.identities = responseData.identities.map((identity) => new IdentityDTO(identity))
     }
   }
 }

--- a/test/unit/libraries/mysterium-tequilapi/client.spec.js
+++ b/test/unit/libraries/mysterium-tequilapi/client.spec.js
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, beforeEach, it} from '../../../helpers/dependencies'
 import HttpTequilapiClient from '../../../../src/libraries/mysterium-tequilapi/client'
 import IdentityDTO from '../../../../src/libraries/mysterium-tequilapi/dto/identity'
 import ProposalDTO from '../../../../src/libraries/mysterium-tequilapi/dto/proposal'
@@ -123,16 +124,18 @@ describe('HttpTequilapiClient', () => {
 
   describe('identitiesList()', () => {
     it('returns identity DTOs', async () => {
-      const response = [
-        {id: '0x1000FACE'},
-        {id: '0x2000FACE'}
-      ]
+      const response = {
+        identities: [
+          {id: '0x1000FACE'},
+          {id: '0x2000FACE'}
+        ]
+      }
       mock.onGet('identities').reply(200, response)
 
       const identities = await api.identitiesList()
       expect(identities).to.have.lengthOf(2)
-      expect(identities[0]).to.deep.equal(new IdentityDTO(response[0]))
-      expect(identities[1]).to.deep.equal(new IdentityDTO(response[1]))
+      expect(identities[0]).to.deep.equal(new IdentityDTO(response.identities[0]))
+      expect(identities[1]).to.deep.equal(new IdentityDTO(response.identities[1]))
     })
 
     it('handles error', async () => {

--- a/test/unit/libraries/mysterium-tequilapi/dto/identities-response.spec.js
+++ b/test/unit/libraries/mysterium-tequilapi/dto/identities-response.spec.js
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, it} from '../../../../helpers/dependencies'
 import {expect} from 'chai'
 import IdentitiesResponseDTO from '../../../../../src/libraries/mysterium-tequilapi/dto/identities-response'
 import IdentityDTO from '../../../../../src/libraries/mysterium-tequilapi/dto/identity'
@@ -22,10 +23,12 @@ import IdentityDTO from '../../../../../src/libraries/mysterium-tequilapi/dto/id
 describe('TequilapiClient DTO', () => {
   describe('IdentitiesResponseDTO', () => {
     it('sets properties', async () => {
-      const response = new IdentitiesResponseDTO([
-        {id: '0x1000FACE'},
-        {id: '0x2000FACE'}
-      ])
+      const response = new IdentitiesResponseDTO({
+        identities: [
+          { id: '0x1000FACE' },
+          { id: '0x2000FACE' }
+        ]
+      })
 
       expect(response.identities).to.have.lengthOf(2)
 


### PR DESCRIPTION
identitiesList response is not an array of identities but
`response = {identities: [IdentityDTO{id: 0xBEEF}]}`