### PR TITLE
Force karma not to fail silently on linter errors

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -1,4 +1,9 @@
 'use strict'
+
+/**
+ * Webpack config used for main process.
+ */
+
 process.env.BABEL_ENV = 'main'
 
 const path = require('path')

--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -41,7 +41,8 @@ let rendererConfig = {
         use: {
           loader: 'eslint-loader',
           options: {
-            formatter: require('eslint-friendly-formatter')
+            formatter: require('eslint-friendly-formatter'),
+            failOnError: true
           }
         }
       },

--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * Webpack config used for renderer process in production (yarn build).
+ */
+
 process.env.BABEL_ENV = 'renderer'
 
 const path = require('path')

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * Webpack config used for renderer process in development (yarn dev).
+ */
+
 process.env.BABEL_ENV = 'web'
 
 const path = require('path')

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -28,7 +28,8 @@ let webConfig = {
         use: {
           loader: 'eslint-loader',
           options: {
-            formatter: require('eslint-friendly-formatter')
+            formatter: require('eslint-friendly-formatter'),
+            failOnError: true
           }
         }
       },


### PR DESCRIPTION
The problem is that currently, if you modify code and re-run tests, tests will be run with **old** code if linter does not pass. This makes debugging painful, because it's common to be debugging old code without realising that 🤮

This change makes tests fail when running linter does not pass:

<img width="1100" alt="screen shot 2018-06-12 at 16 26 54" src="https://user-images.githubusercontent.com/1409983/41293265-7bc6e112-6e5d-11e8-9a5f-0c80dcd53c75.png">

More about `failOnError`: https://github.com/webpack-contrib/eslint-loader#failonerror-default-false