### PR TITLE
Add integration tests to CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:integration:start-server": "karma start test/integration/karma.conf.js",
     "unit:start-server": "karma start test/unit/karma.conf.js",
     "unit:run": "karma run test/unit/karma.conf.js",
-    "ci": "yarn lint && yarn unit && yarn flow"
+    "ci": "yarn flow && yarn lint && yarn unit"
   },
   "build": {
     "productName": "Mysterion",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:integration:start-server": "karma start test/integration/karma.conf.js",
     "unit:start-server": "karma start test/unit/karma.conf.js",
     "unit:run": "karma run test/unit/karma.conf.js",
-    "ci": "yarn flow && yarn lint && yarn unit"
+    "ci": "yarn flow && yarn lint && yarn unit && yarn test:integration"
   },
   "build": {
     "productName": "Mysterion",


### PR DESCRIPTION
`yarn flow` give instant results if running it multiple times - it's very convenient to run `yarn flow` as first step when developing because errors are shown instantly.
Also, integration tests were skipped in CI for some reasons - it doesn't have to be skipped anymore.