### PR TITLE
Fix mysterium client embedding into Mysterion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: js
 cache:
   directories:
   - node_modules
+  # TODO: do not cache bin
   - bin
   - "$HOME/.electron"
   - "$HOME/.cache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: js
 cache:
   directories:
   - node_modules
-  # TODO: do not cache bin
-  - bin
   - "$HOME/.electron"
   - "$HOME/.cache"
 before_cache:

--- a/src/libraries/mysterium-tequilapi/dto/node-healthcheck.js
+++ b/src/libraries/mysterium-tequilapi/dto/node-healthcheck.js
@@ -31,7 +31,7 @@ type NodeHealthcheckDTO = {
  * @returns converted type
  */
 function parseHealthcheckResponse (data: mixed): NodeHealthcheckDTO {
-  const errorMessage = 'Unable to parse response'
+  const errorMessage = `Unable to parse healthcheck response: ${JSON.stringify(data)}`
   if (data == null || typeof data !== 'object') {
     throw new Error(errorMessage)
   }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -100,7 +100,7 @@ export default {
     })
 
     this.rendererCommunication.onShowRendererError((error) => {
-      logger.info('App error received from communication:', error)
+      logger.info('App error received from communication:', error.hint, error.message, 'fatal:', error.fatal)
       this.$store.dispatch(type.OVERLAY_ERROR, error)
     })
 

--- a/test/unit/libraries/mysterium-tequilapi/client.spec.js
+++ b/test/unit/libraries/mysterium-tequilapi/client.spec.js
@@ -74,7 +74,7 @@ describe('HttpTequilapiClient', () => {
 
       const err = await capturePromiseError(api.healthCheck())
       expect(err).to.be.an('error')
-      expect(err.message).to.eql('Unable to parse response')
+      expect(err.message).to.eql('Unable to parse healthcheck response: {"uptime":"1h10m","process":1111,"version":{"commit":"0bcccc","branch":"master","buildNumber":"001"}}')
     })
 
     it('handles error', async () => {

--- a/test/unit/libraries/mysterium-tequilapi/dto/node-healthcheck.spec.js
+++ b/test/unit/libraries/mysterium-tequilapi/dto/node-healthcheck.spec.js
@@ -39,13 +39,13 @@ describe('TequilapiClient DTO', () => {
     it('throws error with empty data', async () => {
       const err = captureError(() => parseHealthcheckResponse({}))
       expect(err).to.be.an('error')
-      expect(err.message).to.eql('Unable to parse response')
+      expect(err.message).to.eql('Unable to parse healthcheck response: {}')
     })
 
     it('throws error with wrong data', async () => {
       const err = captureError(() => parseHealthcheckResponse('I am wrong'))
       expect(err).to.be.an('error')
-      expect(err.message).to.eql('Unable to parse response')
+      expect(err.message).to.eql('Unable to parse healthcheck response: "I am wrong"')
     })
   })
 })

--- a/util_scripts/download-binaries.sh
+++ b/util_scripts/download-binaries.sh
@@ -23,12 +23,17 @@ if [ ! -f "$OPENVPN_BINARY" ] || [ ! -z "$FORCE_DOWNLOAD" ]; then
 else
     echo $OPENVPN_BINARY" exists and download not forced..."
 fi
+
+MYSTERIUM_CLIENT_OSX_BINARY_NAME=mysterium_client_darwin_amd64
+
+MYSTERIUM_CLIENT_OSX_BINARY=$BIN_DIR/$MYSTERIUM_CLIENT_OSX_BINARY_NAME
 MYSTERIUM_CLIENT_BINARY=$BIN_DIR/mysterium_client
 
 if [ ! -f "$MYSTERIUM_CLIENT_BINARY" ] || [ ! -z "$FORCE_DOWNLOAD" ]; then
-    MYSTERIUM_CLIENT_PACKAGE=mysterium_client_darwin_amd64.tar.gz
+    MYSTERIUM_CLIENT_PACKAGE=${MYSTERIUM_CLIENT_OSX_BINARY_NAME}.tar.gz
     $SCRIPT_DIR/git-branch-dl.sh MysteriumNetwork build-artifacts mysterium-node $MYSTERIUM_CLIENT_PACKAGE
     tar -xf $MYSTERIUM_CLIENT_PACKAGE -C $BIN_DIR --strip 1 && rm -rf $MYSTERIUM_CLIENT_PACKAGE
+    mv $MYSTERIUM_CLIENT_OSX_BINARY $MYSTERIUM_CLIENT_BINARY
     chmod +x $MYSTERIUM_CLIENT_BINARY
 else
     echo $MYSTERIUM_CLIENT_BINARY" exists and download not forced..."


### PR DESCRIPTION
Old `mysterium_client` binary was being embedded into Mysterion, because now the downloaded binary is named `mysterium_client_darwin_amd64`, not `mysterium_client`