### PR TITLE
Fix LaunchDaemonProcess not to throw error when daemon is not fast enough

### DIFF
--- a/src/libraries/mysterium-client/launch-daemon/launch-daemon-process.js
+++ b/src/libraries/mysterium-client/launch-daemon/launch-daemon-process.js
@@ -64,7 +64,6 @@ class LaunchDaemonProcess implements Process {
 
   async start (): Promise<void> {
     await this._spawnOsXLaunchDaemon()
-    await this._ensureProcessIsRunning()
   }
 
   async stop (): Promise<void> {
@@ -112,10 +111,6 @@ class LaunchDaemonProcess implements Process {
       // no http server is running on `_daemonPort`, so request results in a failure
       // if some service is responding on daemonPort then additional healthcheck ensures tequilapi is accessible
     }
-  }
-
-  async _ensureProcessIsRunning (): Promise<void> {
-    await this._tequilapi.healthCheck()
   }
 }
 


### PR DESCRIPTION
Because *mysterium_client* starting takes time, http requests are not being server right after starting mysterium client First healthcheck can return error, so we shouldn't expect it to pass.