### PR TITLE
Update openvpn version to have access to windows binaries

### DIFF
--- a/util_scripts/download-binaries.sh
+++ b/util_scripts/download-binaries.sh
@@ -13,7 +13,7 @@ mkdir -p $BIN_DIR
 
 
 
-OPENVPN_VERSION=v2.4.4-1 #standalone build version
+OPENVPN_VERSION=2.4.6-2 #standalone build version
 OPENVPN_BINARY=$BIN_DIR/openvpn
 
 if [ ! -f "$OPENVPN_BINARY" ] || [ ! -z "$FORCE_DOWNLOAD" ]; then


### PR DESCRIPTION
Current release doesn't have windows binaries - new one does: https://github.com/MysteriumNetwork/standalone-openvpn/releases