### PR TITLE
Run copyright header check in yarn ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
 - MYSTERIUM_CLIENT_PREVENT_LOCAL_INSTALL=true yarn
 script:
 - yarn ci
-- util_scripts/check-headers.sh
 before_deploy:
 - bash util_scripts/travis-number.sh
 - mkdir binaries && mkdir releases

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:integration:start-server": "karma start test/integration/karma.conf.js",
     "unit:start-server": "karma start test/unit/karma.conf.js",
     "unit:run": "karma run test/unit/karma.conf.js",
-    "ci": "yarn flow && yarn lint && yarn unit && yarn test:integration && yarn test:coverage",
+    "ci": "util_scripts/check-headers.sh && yarn flow && yarn lint && yarn unit && yarn test:integration && yarn test:coverage",
     "postinstall": "mkdir -p ./bin && cp -r ./node_modules/mysterium-client-bin/bin/* ./bin/"
   },
   "build": {


### PR DESCRIPTION
Builds fail when this check fails, and I keep forget to run manually it so I think it could be included in the `yarn ci` command:)